### PR TITLE
Propagate exceptions

### DIFF
--- a/lib/src/segment_method_channel.dart
+++ b/lib/src/segment_method_channel.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: avoid_print
-
 import 'package:flutter/services.dart';
 import 'package:flutter_segment/src/segment_config.dart';
 import 'package:flutter_segment/src/segment_platform_interface.dart';
@@ -10,14 +8,10 @@ class SegmentMethodChannel extends SegmentPlatform {
   @override
   Future<void> config({
     required SegmentConfig options,
-  }) async {
-    try {
-      await _channel.invokeMethod('config', {
-        'options': options.toMap(),
-      });
-    } on PlatformException catch (exception) {
-      print(exception);
-    }
+  }) {
+    return _channel.invokeMethod('config', {
+      'options': options.toMap(),
+    });
   }
 
   @override
@@ -25,16 +19,12 @@ class SegmentMethodChannel extends SegmentPlatform {
     String? userId,
     required Map<String, dynamic> traits,
     required Map<String, dynamic> options,
-  }) async {
-    try {
-      await _channel.invokeMethod('identify', {
-        'userId': userId,
-        'traits': traits,
-        'options': options,
-      });
-    } on PlatformException catch (exception) {
-      print(exception);
-    }
+  }) {
+    return _channel.invokeMethod('identify', {
+      'userId': userId,
+      'traits': traits,
+      'options': options,
+    });
   }
 
   @override
@@ -42,16 +32,12 @@ class SegmentMethodChannel extends SegmentPlatform {
     required String eventName,
     required Map<String, dynamic> properties,
     required Map<String, dynamic> options,
-  }) async {
-    try {
-      await _channel.invokeMethod('track', {
-        'eventName': eventName,
-        'properties': properties,
-        'options': options,
-      });
-    } on PlatformException catch (exception) {
-      print(exception);
-    }
+  }) {
+    return _channel.invokeMethod('track', {
+      'eventName': eventName,
+      'properties': properties,
+      'options': options,
+    });
   }
 
   @override
@@ -59,16 +45,12 @@ class SegmentMethodChannel extends SegmentPlatform {
     required String screenName,
     required Map<String, dynamic> properties,
     required Map<String, dynamic> options,
-  }) async {
-    try {
-      await _channel.invokeMethod('screen', {
-        'screenName': screenName,
-        'properties': properties,
-        'options': options,
-      });
-    } on PlatformException catch (exception) {
-      print(exception);
-    }
+  }) {
+    return _channel.invokeMethod('screen', {
+      'screenName': screenName,
+      'properties': properties,
+      'options': options,
+    });
   }
 
   @override
@@ -76,31 +58,23 @@ class SegmentMethodChannel extends SegmentPlatform {
     required String groupId,
     required Map<String, dynamic> traits,
     required Map<String, dynamic> options,
-  }) async {
-    try {
-      await _channel.invokeMethod('group', {
-        'groupId': groupId,
-        'traits': traits,
-        'options': options,
-      });
-    } on PlatformException catch (exception) {
-      print(exception);
-    }
+  }) {
+    return _channel.invokeMethod('group', {
+      'groupId': groupId,
+      'traits': traits,
+      'options': options,
+    });
   }
 
   @override
   Future<void> alias({
     required String alias,
     required Map<String, dynamic> options,
-  }) async {
-    try {
-      await _channel.invokeMethod('alias', {
-        'alias': alias,
-        'options': options,
-      });
-    } on PlatformException catch (exception) {
-      print(exception);
-    }
+  }) {
+    return _channel.invokeMethod('alias', {
+      'alias': alias,
+      'options': options,
+    });
   }
 
   @override
@@ -109,60 +83,36 @@ class SegmentMethodChannel extends SegmentPlatform {
   }
 
   @override
-  Future<void> reset() async {
-    try {
-      await _channel.invokeMethod('reset');
-    } on PlatformException catch (exception) {
-      print(exception);
-    }
+  Future<void> reset() {
+    return _channel.invokeMethod('reset');
   }
 
   @override
-  Future<void> disable() async {
-    try {
-      await _channel.invokeMethod('disable');
-    } on PlatformException catch (exception) {
-      print(exception);
-    }
+  Future<void> disable() {
+    return _channel.invokeMethod('disable');
   }
 
   @override
-  Future<void> enable() async {
-    try {
-      await _channel.invokeMethod('enable');
-    } on PlatformException catch (exception) {
-      print(exception);
-    }
+  Future<void> enable() {
+    return _channel.invokeMethod('enable');
   }
 
   @override
-  Future<void> flush() async {
-    try {
-      await _channel.invokeMethod('flush');
-    } on PlatformException catch (exception) {
-      print(exception);
-    }
+  Future<void> flush() {
+    return _channel.invokeMethod('flush');
   }
 
   @override
   Future<void> debug(bool enabled) async {
-    try {
-      await _channel.invokeMethod('debug', {
-        'debug': enabled,
-      });
-    } on PlatformException catch (exception) {
-      print(exception);
-    }
+    return _channel.invokeMethod('debug', {
+      'debug': enabled,
+    });
   }
 
   @override
   Future<void> setContext(Map<String, dynamic> context) async {
-    try {
-      await _channel.invokeMethod('setContext', {
-        'context': context,
-      });
-    } on PlatformException catch (exception) {
-      print(exception);
-    }
+    return _channel.invokeMethod('setContext', {
+      'context': context,
+    });
   }
 }


### PR DESCRIPTION
Removed the `try/catch` statements. We want to detect if something is not working (the app should handle exceptions).