### PR TITLE
Fix iOS userId null

### DIFF
--- a/ios/Classes/FlutterSegmentPlugin.m
+++ b/ios/Classes/FlutterSegmentPlugin.m
@@ -185,18 +185,11 @@ static BOOL wasSetupFromFile = NO;
     NSString *userId = call.arguments[@"userId"];
     NSDictionary *traits = call.arguments[@"traits"];
     NSDictionary *options = call.arguments[@"options"];
-      
-      if ([userId isEqual:[NSNull null]]){
-          [[SEGAnalytics sharedAnalytics] identify: nil
-                            traits: traits
-                           options: options];
-      } else {
-          [[SEGAnalytics sharedAnalytics] identify: userId
-                            traits: traits
-                           options: options];
-      }
 
-
+    userId = [userId isEqual:[NSNull null]]? nil: userId;
+    [[SEGAnalytics sharedAnalytics] identify: userId
+                      traits: traits
+                     options: options];
 
     result([NSNumber numberWithBool:YES]);
   }

--- a/ios/Classes/FlutterSegmentPlugin.m
+++ b/ios/Classes/FlutterSegmentPlugin.m
@@ -185,10 +185,18 @@ static BOOL wasSetupFromFile = NO;
     NSString *userId = call.arguments[@"userId"];
     NSDictionary *traits = call.arguments[@"traits"];
     NSDictionary *options = call.arguments[@"options"];
+      
+      if ([userId isEqual:[NSNull null]]){
+          [[SEGAnalytics sharedAnalytics] identify: nil
+                            traits: traits
+                           options: options];
+      } else {
+          [[SEGAnalytics sharedAnalytics] identify: userId
+                            traits: traits
+                           options: options];
+      }
 
-    [[SEGAnalytics sharedAnalytics] identify: userId
-                      traits: traits
-                     options: options];
+
 
     result([NSNumber numberWithBool:YES]);
   }


### PR DESCRIPTION
Fixes a problem where `userId` would not be set correctly.

I don't have much experience in objective-c, but I think this is the problem:
`NSNull` and `nil` are not the same thing.
The `userId` gets set to `NSNull`, but the `identify` function expects it to be `nil`.

@Truba Maybe there is a cleaner way to write this, feel free to change it.